### PR TITLE
feat: Convert Inferno into a layer

### DIFF
--- a/src/main/java/org/terasology/inferno/generator/InfernoWorldGenerator.java
+++ b/src/main/java/org/terasology/inferno/generator/InfernoWorldGenerator.java
@@ -15,9 +15,6 @@
  */
 package org.terasology.inferno.generator;
 
-import org.terasology.caves.CaveFacetProvider;
-import org.terasology.caves.CaveRasterizer;
-import org.terasology.caves.CaveToDensityProvider;
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
@@ -34,19 +31,6 @@ import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
 import org.terasology.core.world.generator.rasterizers.TreeRasterizer;
 import org.terasology.engine.SimpleUri;
-import org.terasology.inferno.generator.providers.ElevationProvider;
-import org.terasology.inferno.generator.providers.FloraProvider;
-import org.terasology.inferno.generator.providers.InfernalTreeProvider;
-import org.terasology.inferno.generator.providers.InfernoCeilingProvider;
-import org.terasology.inferno.generator.providers.InfernoSurfaceProvider;
-import org.terasology.inferno.generator.providers.LavaFallsProvider;
-import org.terasology.inferno.generator.providers.LavaHutProvider;
-import org.terasology.inferno.generator.providers.LavaLevelProvider;
-import org.terasology.inferno.generator.rasterizers.InfernalTreeRasterizer;
-import org.terasology.inferno.generator.rasterizers.InfernoFloraRasterizer;
-import org.terasology.inferno.generator.rasterizers.InfernoWorldRasterizer;
-import org.terasology.inferno.generator.rasterizers.LavaFallsRasterizer;
-import org.terasology.inferno.generator.rasterizers.LavaHutRasterizer;
 import org.terasology.math.geom.ImmutableVector2i;
 import org.terasology.registry.In;
 import org.terasology.world.generation.BaseFacetedWorldGenerator;
@@ -90,24 +74,8 @@ public class InfernoWorldGenerator extends BaseFacetedWorldGenerator {
                 .addRasterizer(new SolidRasterizer())
                 .addRasterizer(new FloraRasterizer())
                 .addRasterizer(new TreeRasterizer())
+
                 // Inferno
-                .addProvider(new InfernoSurfaceProvider(INFERNO_DEPTH))
-                .addProvider(new InfernoCeilingProvider(INFERNO_HEIGHT))
-                .addProvider(new ElevationProvider())
-                .addProvider(new LavaLevelProvider())
-                .addProvider(new LavaFallsProvider())
-                .addProvider(new FloraProvider())
-                .addProvider(new InfernalTreeProvider())
-                .addProvider(new LavaHutProvider())
-                .addRasterizer(new InfernoWorldRasterizer())
-                // Caves rasterized right after main rasterizer
-                .addRasterizer(new CaveRasterizer())
-                .addRasterizer(new InfernoFloraRasterizer())
-                .addRasterizer(new LavaHutRasterizer())
-                .addRasterizer(new InfernalTreeRasterizer())
-                .addRasterizer(new LavaFallsRasterizer())
-                // Caves
-                .addProvider(new CaveFacetProvider())
-                .addProvider(new CaveToDensityProvider());
+                .addPlugins();
     }
 }

--- a/src/main/java/org/terasology/inferno/generator/InfernoZonePlugin.java
+++ b/src/main/java/org/terasology/inferno/generator/InfernoZonePlugin.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.inferno.generator;
+
+import org.terasology.caves.CaveFacetProvider;
+import org.terasology.caves.CaveRasterizer;
+import org.terasology.caves.CaveToDensityProvider;
+import org.terasology.inferno.generator.providers.ElevationProvider;
+import org.terasology.inferno.generator.providers.FloraProvider;
+import org.terasology.inferno.generator.providers.InfernalTreeProvider;
+import org.terasology.inferno.generator.providers.InfernoCeilingProvider;
+import org.terasology.inferno.generator.providers.InfernoSurfaceProvider;
+import org.terasology.inferno.generator.providers.LavaFallsProvider;
+import org.terasology.inferno.generator.providers.LavaHutProvider;
+import org.terasology.inferno.generator.providers.LavaLevelProvider;
+import org.terasology.inferno.generator.rasterizers.InfernalTreeRasterizer;
+import org.terasology.inferno.generator.rasterizers.InfernoFloraRasterizer;
+import org.terasology.inferno.generator.rasterizers.InfernoWorldRasterizer;
+import org.terasology.inferno.generator.rasterizers.LavaFallsRasterizer;
+import org.terasology.inferno.generator.rasterizers.LavaHutRasterizer;
+import org.terasology.world.generator.plugin.RegisterPlugin;
+import org.terasology.world.zones.ConstantLayerThickness;
+import org.terasology.world.zones.LayeredZoneRegionFunction;
+import org.terasology.world.zones.ZonePlugin;
+
+import static org.terasology.inferno.generator.InfernoWorldGenerator.INFERNO_DEPTH;
+import static org.terasology.inferno.generator.InfernoWorldGenerator.INFERNO_HEIGHT;
+import static org.terasology.world.zones.LayeredZoneRegionFunction.LayeredZoneOrdering.DEEP_UNDERGROUND;
+
+@RegisterPlugin
+public class InfernoZonePlugin extends ZonePlugin {
+
+    public InfernoZonePlugin() {
+        super("Inferno", new LayeredZoneRegionFunction(new ConstantLayerThickness(200_200), DEEP_UNDERGROUND));
+
+        // Inferno
+        addProvider(new InfernoSurfaceProvider(INFERNO_DEPTH));
+        addProvider(new InfernoCeilingProvider(INFERNO_HEIGHT));
+        addProvider(new ElevationProvider());
+        addProvider(new LavaLevelProvider());
+        addProvider(new LavaFallsProvider());
+        addProvider(new FloraProvider());
+        addProvider(new InfernalTreeProvider());
+        addProvider(new LavaHutProvider());
+        addRasterizer(new InfernoWorldRasterizer());
+        // Caves rasterized right after main rasterizer
+        addRasterizer(new CaveRasterizer());
+        addRasterizer(new InfernoFloraRasterizer());
+        addRasterizer(new LavaHutRasterizer());
+        addRasterizer(new InfernalTreeRasterizer());
+        addRasterizer(new LavaFallsRasterizer());
+        // Caves
+        addProvider(new CaveFacetProvider());
+        addProvider(new CaveToDensityProvider());
+    }
+}
+
+
+


### PR DESCRIPTION
**! Note:** This uses code in the `v2.0.0` engine branch, so should be placed into a v2 module branch

This PR updates Inferno to be a layered zone (described [here](https://github.com/Terasology/TutorialWorldGeneration/wiki/Zones)) and a world plugin, so that it is added to every world generator when the Inferno module is active, and it doesn't need its own world generator.

This means that, after enabling the Inferno module, any world generator that is picked will have an Inferno layer. Nothing about the system or the Resurrection Idol is changed, and the actual generation is exactly the same.

I haven't removed the existing Inferno world generator, but it might be a good idea to remove that to reduce confusion about where Inferno is enabled.