### PR TITLE
Teleportation bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 Potential issue: https://github.com/iojw/Inferno/issues/1
 ### Installation Note
-Before loading the world make sure that the Inferno world generator is selected.
-- Click on the **Continue to Universe Setup** button when in the Advanced menu![](https://imgur.com/WcD3ix5.png)
-- Select **Inferno** from the World Generator dropdown and click Add ![](https://imgur.com/08tEiOc.png)
-- Click on **Continue to Pregeneration**
-- Click on **Continue to Spawn Preview**
-- Click on **Start Playing** and enjoy the game :)
-
+Before loading the world make sure that the Inferno world template is selected ![](http://i.imgur.com/6peH4c3.png)
 # Inferno
 
 **in·fer·no**  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 Potential issue: https://github.com/iojw/Inferno/issues/1
+### Installation Note
+Before loading the world make sure that the Inferno world generator is selected.
+- Click on the **Continue to Universe Setup** button when in the Advanced menu![](https://imgur.com/WcD3ix5.png)
+- Select **Inferno** from the World Generator dropdown and click Add ![](https://imgur.com/08tEiOc.png)
+- Click on **Continue to Pregeneration**
+- Click on **Continue to Spawn Preview**
+- Click on **Start Playing** and enjoy the game :)
 
 # Inferno
 

--- a/module.txt
+++ b/module.txt
@@ -10,5 +10,7 @@
         {"id": "DamagingBlocks", "minVersion" : "0.2.0"},
         {"id": "ChiselBlocks","minVersion" : "0.1.0"}
     ],
-    "serverSideOnly" : false
+    "serverSideOnly" : false,
+    "isGameplay" : "true",
+    "defaultWorldGenerator" : "Inferno:InfernoWorld"
 }

--- a/src/main/java/org/terasology/inferno/generator/InfernoWorldGenerator.java
+++ b/src/main/java/org/terasology/inferno/generator/InfernoWorldGenerator.java
@@ -21,14 +21,14 @@ import org.terasology.caves.CaveToDensityProvider;
 import org.terasology.core.world.generator.facetProviders.BiomeProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultFloraProvider;
 import org.terasology.core.world.generator.facetProviders.DefaultTreeProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinBaseSurfaceProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinHillsAndMountainsProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinHumidityProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinOceanProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinRiverProvider;
+import org.terasology.core.world.generator.facetProviders.PerlinSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.PlateauProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
-import org.terasology.core.world.generator.facetProviders.SimplexBaseSurfaceProvider;
-import org.terasology.core.world.generator.facetProviders.SimplexHillsAndMountainsProvider;
-import org.terasology.core.world.generator.facetProviders.SimplexHumidityProvider;
-import org.terasology.core.world.generator.facetProviders.SimplexOceanProvider;
-import org.terasology.core.world.generator.facetProviders.SimplexRiverProvider;
-import org.terasology.core.world.generator.facetProviders.SimplexSurfaceTemperatureProvider;
 import org.terasology.core.world.generator.facetProviders.SurfaceToDensityProvider;
 import org.terasology.core.world.generator.rasterizers.FloraRasterizer;
 import org.terasology.core.world.generator.rasterizers.SolidRasterizer;
@@ -76,12 +76,12 @@ public class InfernoWorldGenerator extends BaseFacetedWorldGenerator {
                 // default Perlin
                 .setSeaLevel(seaLevel)
                 .addProvider(new SeaLevelProvider(seaLevel))
-                .addProvider(new SimplexHumidityProvider())
-                .addProvider(new SimplexSurfaceTemperatureProvider())
-                .addProvider(new SimplexBaseSurfaceProvider())
-                .addProvider(new SimplexRiverProvider())
-                .addProvider(new SimplexOceanProvider())
-                .addProvider(new SimplexHillsAndMountainsProvider())
+                .addProvider(new PerlinHumidityProvider())
+                .addProvider(new PerlinSurfaceTemperatureProvider())
+                .addProvider(new PerlinBaseSurfaceProvider())
+                .addProvider(new PerlinRiverProvider())
+                .addProvider(new PerlinOceanProvider())
+                .addProvider(new PerlinHillsAndMountainsProvider())
                 .addProvider(new BiomeProvider())
                 .addProvider(new SurfaceToDensityProvider())
                 .addProvider(new DefaultFloraProvider())


### PR DESCRIPTION
Resolves #7 
In older versions of Terasology, the world generator was auto-selected, and there wasn’t an additional selector for “Worlds”, so Inferno worked out of the box just by selecting the module. But now you'd have to add in the Inferno world generator manually and this is never mentioned.
This PR adds more installation details to the readme to prevent confusion in the future. Changes to Simplex are also reverted to maintain consistency.