### PR TITLE
Move cave stuff to the correct packages

### DIFF
--- a/src/main/java/org/terasology/inferno/generator/InfernoZonePlugin.java
+++ b/src/main/java/org/terasology/inferno/generator/InfernoZonePlugin.java
@@ -15,9 +15,8 @@
  */
 package org.terasology.inferno.generator;
 
-import org.terasology.caves.CaveFacetProvider;
-import org.terasology.caves.CaveRasterizer;
-import org.terasology.caves.CaveToDensityProvider;
+import org.terasology.inferno.generator.providers.CaveFacetProvider;
+import org.terasology.inferno.generator.providers.CaveToDensityProvider;
 import org.terasology.inferno.generator.providers.ElevationProvider;
 import org.terasology.inferno.generator.providers.FloraProvider;
 import org.terasology.inferno.generator.providers.InfernalTreeProvider;
@@ -26,6 +25,7 @@ import org.terasology.inferno.generator.providers.InfernoSurfaceProvider;
 import org.terasology.inferno.generator.providers.LavaFallsProvider;
 import org.terasology.inferno.generator.providers.LavaHutProvider;
 import org.terasology.inferno.generator.providers.LavaLevelProvider;
+import org.terasology.inferno.generator.rasterizers.CaveRasterizer;
 import org.terasology.inferno.generator.rasterizers.InfernalTreeRasterizer;
 import org.terasology.inferno.generator.rasterizers.InfernoFloraRasterizer;
 import org.terasology.inferno.generator.rasterizers.InfernoWorldRasterizer;

--- a/src/main/java/org/terasology/inferno/generator/facets/CaveFacet.java
+++ b/src/main/java/org/terasology/inferno/generator/facets/CaveFacet.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.caves;
+package org.terasology.inferno.generator.facets;
 
 import org.joml.Vector3ic;
 import org.terasology.world.block.BlockRegion;

--- a/src/main/java/org/terasology/inferno/generator/providers/CaveFacetProvider.java
+++ b/src/main/java/org/terasology/inferno/generator/providers/CaveFacetProvider.java
@@ -1,11 +1,12 @@
 // Copyright 2020 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-package org.terasology.caves;
+package org.terasology.inferno.generator.providers;
 
 import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.entitySystem.Component;
+import org.terasology.inferno.generator.facets.CaveFacet;
 import org.terasology.inferno.generator.facets.InfernoSurfaceHeightFacet;
 import org.terasology.nui.properties.Range;
 import org.terasology.utilities.procedural.AbstractNoise;

--- a/src/main/java/org/terasology/inferno/generator/providers/CaveToDensityProvider.java
+++ b/src/main/java/org/terasology/inferno/generator/providers/CaveToDensityProvider.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.caves;
+package org.terasology.inferno.generator.providers;
 
 import org.joml.Vector3ic;
+import org.terasology.inferno.generator.facets.CaveFacet;
 import org.terasology.world.generation.Facet;
 import org.terasology.world.generation.FacetProvider;
 import org.terasology.world.generation.GeneratingRegion;

--- a/src/main/java/org/terasology/inferno/generator/rasterizers/CaveRasterizer.java
+++ b/src/main/java/org/terasology/inferno/generator/rasterizers/CaveRasterizer.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.caves;
+package org.terasology.inferno.generator.rasterizers;
 
 import org.joml.Vector3ic;
+import org.terasology.inferno.generator.facets.CaveFacet;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;


### PR DESCRIPTION
This fixes a bug where if you use the Caves module in a workspace where Inferno is even present (it doesn't have to be active), it will fail, because the engine gets confused between Caves's versions of classes and Inferno's identically named classes. I haven't actually tested that Inferno still works, but I've just moved stuff around, and it still compiles, so it should be fine.