### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/inferno/generator/providers/CaveFacetProvider.java
+++ b/src/main/java/org/terasology/inferno/generator/providers/CaveFacetProvider.java
@@ -95,7 +95,7 @@ public class CaveFacetProvider implements ConfigurableFacetProvider {
         this.configuration = (CaveFacetProviderConfiguration) configuration;
     }
 
-    private static class CaveFacetProviderConfiguration implements Component<CaveFacetProviderConfiguration> {
+    public static class CaveFacetProviderConfiguration implements Component<CaveFacetProviderConfiguration> {
         @Range(min = 0, max = 1f, increment = 0.05f, precision = 2, description = "Amount of Caves")
         public float amountOfCaves = 0.75f;
         @Range(min = 0, max = 2f, increment = 0.05f, precision = 2, description = "Width")


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191